### PR TITLE
Make rvm group before adding ubuntu to rvm group

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,10 @@ bootstrap() {
                         ncurses-dev automake libtool bison subversion libgdbm-dev pkg-config \
                         libffi-dev nodejs libqt4-dev libqtwebkit-dev
 
+                    if [ -z $(cat /etc/group | grep 'rvm') ]
+                    then
+                        sudo groupadd rvm
+                    fi
                     sudo usermod -a -G rvm ubuntu #add the ubuntu user to the rvm group
 
                     ;; # end Ubuntu


### PR DESCRIPTION
- If rvm group doesn't exist, adding ubuntu to rvm group fails.
- Before adding it to the group, make rvm group.

@dmytro 
Please review.
